### PR TITLE
Ensuring changes to icon/webui labels are respected

### DIFF
--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
 export HOME=/root
+export DOCKER_JSON=/usr/local/emhttp/state/plugins/dynamix.docker.manager/docker.json
 
 case $1 in
 
   up)
+    docker compose -f "$2" -p "$3" ps -a |
+      awk '{if (NR!=1) {printf("%s.\"%s\"", sep, $1); sep=", "}}' |
+      xargs -0 -I {} jq 'del({})' $DOCKER_JSON > $DOCKER_JSON
     docker compose -f "$2" -p "$3" up -d 2>&1
     ;;
 
   down)
+    docker compose -f "$2" -p "$3" ps -a |
+      awk '{if (NR!=1) {printf("%s.\"%s\"", sep, $1); sep=", "}}' |
+      xargs -0 -I {} jq 'del({})' $DOCKER_JSON > $DOCKER_JSON
     docker compose -f "$2" -p "$3" down  2>&1
     ;;
 

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 export HOME=/root
-export DOCKER_JSON=/usr/local/emhttp/state/plugins/dynamix.docker.manager/docker.json
+DOCKER_MANAGER=/usr/local/emhttp/state/plugins/dynamix.docker.manager
+DOCKER_JSON=$DOCKER_MANAGER/docker.json
+DOCKER_IMAGES=$DOCKER_MANAGER/images
+UNRAID_IMAGES=/var/lib/docker/unraid/images
 
 case $1 in
 
@@ -9,6 +12,9 @@ case $1 in
     docker compose -f "$2" -p "$3" ps -a |
       awk '{if (NR!=1) {printf("%s.\"%s\"", sep, $1); sep=", "}}' |
       xargs -0 -I {} jq 'del({})' $DOCKER_JSON > $DOCKER_JSON
+    docker compose -f "$2" -p "$3" ps -a |
+      awk '{if (NR!=1) {print $1}}' |
+      xargs -I {} find $DOCKER_IMAGES $UNRAID_IMAGES -name {}.png -delete
     docker compose -f "$2" -p "$3" up -d 2>&1
     ;;
 
@@ -16,6 +22,9 @@ case $1 in
     docker compose -f "$2" -p "$3" ps -a |
       awk '{if (NR!=1) {printf("%s.\"%s\"", sep, $1); sep=", "}}' |
       xargs -0 -I {} jq 'del({})' $DOCKER_JSON > $DOCKER_JSON
+    docker compose -f "$2" -p "$3" ps -a |
+      awk '{if (NR!=1) {print $1}}' |
+      xargs -I {} find $DOCKER_IMAGES $UNRAID_IMAGES -name {}.png -delete
     docker compose -f "$2" -p "$3" down  2>&1
     ;;
 


### PR DESCRIPTION
This PR proposes 2 changes. The goal of these 2 changes are to resolve issue #9.

The first is to ensure that projects that are spun down are removed from
unRAID's cache by removing relevant entries in
`/usr/local/emhttp/plugins/dynamix.docker.manager/docker.json`. This ensures
that changes to the webui label are respected. This change is not a big change.

The second is to ensure that all cached icon files are removed when a project is
spun down. The files are cached in 2 locations: `/var/lib/docker/unraid/images`
and `/usr/local/emhttp/plugins/dynamix.docker.manager/images`. This is a hacky
attempt to ensure that changes to the icon label are respected. The reason I say
so is because this means icon files has to be downloaded every time the project
is spun up -- possibly many I/O operations.

Resolves #9