### PR TITLE
Compose startup fix for Unraid 6.12.4

### DIFF
--- a/source/compose.manager/event/started
+++ b/source/compose.manager/event/started
@@ -29,10 +29,10 @@ for dir in $COMPOSE_ROOT/*; do
                     if [ -f "$dir/indirect" ]; then
                         indirect=${dir}/indirect
                         indirect=$(< "${indirect}")
-                        eval $COMPOSE_WRAPPER -c up -d ${indirect@Q} -p ${name} $override > /dev/null &
+                        eval $COMPOSE_WRAPPER -c up -d ${indirect@Q} -p ${name} --force-recreate $override > /dev/null &
                     else
                         dir="$dir/docker-compose.yml"
-                        eval $COMPOSE_WRAPPER -c up -f ${dir@Q} -p ${name} $override > /dev/null &
+                        eval $COMPOSE_WRAPPER -c up -f ${dir@Q} -p ${name} --force-recreate $override > /dev/null &
                     fi
                 fi
             fi


### PR DESCRIPTION
Added --force-recreate on startup to solve the issue with compose and the network ID on start.