### PR TITLE
Compose startup fix for Unraid 6.12.4

### DIFF
--- a/source/compose.manager/event/started
+++ b/source/compose.manager/event/started
@@ -29,10 +29,10 @@ for dir in $COMPOSE_ROOT/*; do
                     if [ -f "$dir/indirect" ]; then
                         indirect=${dir}/indirect
                         indirect=$(< "${indirect}")
-                        eval $COMPOSE_WRAPPER -c up -d ${indirect@Q} -p ${name} $override > /dev/null &
+                        eval $COMPOSE_WRAPPER -c autostart -d ${indirect@Q} -p ${name} $override > /dev/null &
                     else
                         dir="$dir/docker-compose.yml"
-                        eval $COMPOSE_WRAPPER -c up -f ${dir@Q} -p ${name} $override > /dev/null &
+                        eval $COMPOSE_WRAPPER -c autostart -f ${dir@Q} -p ${name} $override > /dev/null &
                     fi
                 fi
             fi

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -54,7 +54,7 @@ case $command in
     if [ "$debug" = true ]; then
       logger "docker compose $files -p "$name" up -d"
     fi
-    eval docker compose $files -p "$name" up -d 2>&1
+    eval docker compose $files -p "$name" up --force-recreate -d 2>&1
     ;;
 
   down)

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -54,6 +54,13 @@ case $command in
     if [ "$debug" = true ]; then
       logger "docker compose $files -p "$name" up -d"
     fi
+    eval docker compose $files -p "$name" up -d 2>&1
+    ;;
+
+  autostart)
+    if [ "$debug" = true ]; then
+      logger "docker compose $files -p "$name" up --force-recreate -d"
+    fi
     eval docker compose $files -p "$name" up --force-recreate -d 2>&1
     ;;
 


### PR DESCRIPTION
Added the wrapper autostart to execute the compuse up with the --force-recreate flag on autostart. This solves the issue with the changed network id and compose.