### PR TITLE
Allow setting the .env file manually

### DIFF
--- a/source/compose.manager/php/compose_util.php
+++ b/source/compose.manager/php/compose_util.php
@@ -70,6 +70,11 @@ function echoComposeCommand($action)
 			$composeCommand[] = $composeOverride;
 		}
 
+		if ( is_file("$path/envToUse") ) {
+			$envToUse = "-e" . trim(file_get_contents("$path/envToUse"));
+			$composeCommand[] = $envToUse;
+		}
+
 		if( $debug ) {
 			$composeCommand[] = "--debug";
 		}

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 export HOME=/root
 
-SHORT=c:,f:,p:,d:,o:
-LONG=command:,file:,project_name:,project_dir:,override:,debug,recreate
+SHORT=e:,c:,f:,p:,d:,o:
+LONG=env,command:,file:,project_name:,project_dir:,override:,debug,recreate
 OPTS=$(getopt -a -n compose --options $SHORT --longoptions $LONG -- "$@")
 
 eval set -- "$OPTS"
 
+envToUse=""
 files=""
 project_dir=""
 other_options=""
@@ -15,6 +16,19 @@ debug=false
 while :
 do
   case "$1" in
+    -e | --env )
+      envToUse="$2"
+      shift 2
+      
+      if [ -f $envToUse ]; then
+        echo "using .env: $envToUse"
+      else
+        echo ".env doesn't exist: $envToUse"
+        exit
+      fi
+
+      envToUse="--env-file $envToUse"
+      ;;
     -c | --command )
       command="$2"
       shift 2
@@ -57,27 +71,27 @@ case $command in
 
   up)
     if [ "$debug" = true ]; then
-      logger "docker compose $files -p "$name" up $other_options -d"
+      logger "docker compose $envToUse $files -p "$name" up $other_options -d"
     fi
-    eval docker compose $files -p "$name" up $other_options -d 2>&1
+    eval docker compose $envToUse $files -p "$name" up $other_options -d 2>&1
     ;;
 
   down)
     if [ "$debug" = true ]; then
-      logger "docker compose $files -p "$name" down"
+      logger "docker compose $envToUse $files -p "$name" down"
     fi
-    eval docker compose $files -p "$name" down  2>&1
+    eval docker compose $envToUse $files -p "$name" down  2>&1
     ;;
     
   update)
     if [ "$debug" = true ]; then
-      logger "docker compose $files -p "$name" images -q"
-      logger "docker compose $files -p "$name" pull"
-      logger "docker compose $files -p "$name" up -d --build"
+      logger "docker compose $envToUse $files -p "$name" images -q"
+      logger "docker compose $envToUse $files -p "$name" pull"
+      logger "docker compose $envToUse $files -p "$name" up -d --build"
     fi
 
     images=()
-    images+=( $(docker compose $files -p "$name" images -q) )
+    images+=( $(docker compose $envToUse $files -p "$name" images -q) )
 
     if [ ${#images[@]} -eq 0 ]; then   
       delete="-f"
@@ -94,10 +108,11 @@ case $command in
       images=( ${images[*]##sha256:} )
     fi
     
-    eval docker compose $files -p "$name" pull 2>&1
-    eval docker compose $files -p "$name" up -d --build 2>&1
+    eval docker compose $envToUse $files -p "$name" pull 2>&1
+    eval docker compose $envToUse $files -p "$name" up -d --build 2>&1
+    # eval docker compose $envToUse $files -p "$name" up -d --build 2>&1
 
-    new_images=( $(docker compose $files -p "$name" images -q) )
+    new_images=( $(docker compose $envToUse $files -p "$name" images -q) )
     for target in "${new_images[@]}"; do
       for i in "${!images[@]}"; do
         if [[ ${images[i]} = $target ]]; then
@@ -116,9 +131,9 @@ case $command in
 
   stop)
     if [ "$debug" = true ]; then
-      logger "docker compose $files -p "$name" stop"
+      logger "docker compose $envToUse $files -p "$name" stop"
     fi
-    eval docker compose $files -p "$name" stop  2>&1
+    eval docker compose $envToUse $files -p "$name" stop  2>&1
     ;;
 
   list) 
@@ -130,9 +145,9 @@ case $command in
 
   logs)
     if [ "$debug" = true ]; then
-      logger "docker compose $files logs -f"
+      logger "docker compose $envToUse $files logs -f"
     fi
-    eval docker compose $files logs -f 2>&1
+    eval docker compose $envToUse $files logs -f 2>&1
     ;;
 
   *)


### PR DESCRIPTION
This addresses #23 
Create a file called envToUse in the compose manager project folder (/boot/config/plugins/compose.manager/projects/{PROJECT NAME}) and put the full path to the env you'd like to use.
This allows you to use the same .env across multiple compose files.

Note: I haven't got any UI integration for this as an update to the plugin wiped out my work - guess I should've worked on a copy.  I might look to re-implement if there's interest.  For me, I use code server to manage/edit my copmpose files so it's not needed.
