### PR TITLE
Update status

### DIFF
--- a/source/compose.manager/php/DockerUpdate.php
+++ b/source/compose.manager/php/DockerUpdate.php
@@ -1,0 +1,47 @@
+<?PHP
+/* This file and functionality is based on  and uses the Dynamix Docker Danager from unRaid
+ * Script by mtongnz, Jan 2024
+ * 
+ * Copyright 2005-2022, Lime Technology
+ * Copyright 2014-2022, Guilherme Jardim, Eric Schultz, Jon Panozzo.
+ * Copyright 2012-2022, Bergware International.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+?>
+<?
+$docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+require_once "$docroot/plugins/dynamix.docker.manager/include/DockerClient.php";
+
+$images = array();
+
+// Take stdin from compose.sh and put into images array
+$f = fopen( 'php://stdin', 'r' );
+while( $image = fgets( $f ) )
+  $images[] = trim($image);
+fclose( $f );
+$images = array_unique($images);
+
+
+echo "\nUpdating unRaid's image version details for " . count($images) . " image(s):\n";
+$DockerUpdate = new DockerUpdate();
+
+foreach( $images as $image ) {
+    echo " - updating " . $image . "\n";
+
+    // Delete current info to force an update
+    $updateStatus = DockerUtil::loadJSON($dockerManPaths['update-status']);
+    $updateStatus[$image]['local'] = null;
+    DockerUtil::saveJSON($dockerManPaths['update-status'], $updateStatus);
+
+    // Update the version info
+    $DockerUpdate->reloadUpdateStatus($image);
+}
+
+echo "unRaid image versions updated\n";
+?>

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -205,6 +205,7 @@ $(function() {
                                     <input type='button' onclick='editStack(&quot;"+myID+"&quot;);' value='Edit Stack'> \
                                     <input type='button' onclick='deleteStack(&quot;"+myID+"&quot;);' value='Delete Stack' "+disabled+"> \
                                     <input type='button' onclick='ComposeLogs(&quot;"+myID+"&quot;);' value='Logs' "+notdisabled+"> \
+                                    <input type='button' onclick='ComposeCheckUpdates(&quot;"+myID+"&quot;);' value='Check for Updates'> \
                                     </center>");
 		}
 	});
@@ -751,6 +752,19 @@ function ComposeLogs(myID) {
   $.post(compURL,{action:'composeLogs',path:path},function(data) {
     if (data) {
       openBox(data,"Stack "+basename(path)+" Logs",height,width,true);
+    }
+  })
+}
+
+function ComposeCheckUpdates(myID) {
+  var height = 800;
+  var width = 1200;
+  $("#"+myID).tooltipster("close");
+  var script = $("#"+myID).attr("data-scriptname");
+  var path = compose_root + "/" + script;
+  $.post(compURL,{action:'composeCheckUpdates',path:path},function(data) {
+    if (data) {
+      openBox(data,"Check for Available Updates to Stack "+basename(path),height,width,true);
     }
   })
 }

--- a/source/compose.manager/php/compose_util.php
+++ b/source/compose.manager/php/compose_util.php
@@ -132,5 +132,8 @@ switch ($_POST['action']) {
 	case 'composeLogs':
 		echoComposeCommand('logs');
 		break;		
+	case 'composeCheckUpdates':
+		echoComposeCommand('checkUpdates');
+			break;	
 }
 ?>

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 export HOME=/root
 
+phpScriptDir=/usr/local/emhttp/plugins/compose.manager/php
+
 SHORT=e:,c:,f:,p:,d:,o:,g:
 LONG=env,command:,file:,project_name:,project_dir:,override:,profile:,debug,recreate
 OPTS=$(getopt -a -n compose --options $SHORT --longoptions $LONG -- "$@")
@@ -132,6 +134,9 @@ case $command in
       fi
       eval docker rmi ${images[*]}
     fi
+    
+    # Update unRaid's local/remote image versions database so GUI shows correct info about updates
+    docker compose -p "$name" ps --format "{{.Image}}" | php $phpScriptDir/DockerUpdate.php 2>&1
     ;;
 
   stop)

--- a/source/compose.manager/scripts/compose.sh
+++ b/source/compose.manager/scripts/compose.sh
@@ -160,6 +160,11 @@ case $command in
     eval docker compose $envFile $files $options logs -f 2>&1
     ;;
 
+  checkUpdates)
+    # Update unRaid's local/remote image versions database so GUI shows correct info about updates
+    docker compose -p "$name" ps --format "{{.Image}}" | php $phpScriptDir/DockerUpdate.php 2>&1
+    ;;
+
   *)
     echo "unknown command"
     echo $command 


### PR DESCRIPTION
This PR fixes the update status reported in unRaid for compose created containers.
It uses the DockerUpdate class from Dynamix Docker Manager (i.e. dockerman).

This will run when Compose Manager updates stacks. There is also a "check for updates" button for each compose project to manually do the check.