### PR TITLE
Support for compose files with different names (as per spec)

### DIFF
--- a/source/compose.manager/event/started
+++ b/source/compose.manager/event/started
@@ -26,16 +26,33 @@ fi
 
 for dir in $COMPOSE_ROOT/*; do
     if [ -d "$dir" ]; then
-        if [ -f "$dir/docker-compose.yml" ] || [ -f "$dir/indirect" ]; then
+        # Check if any valid compose file exists
+        if [ -f "$dir/compose.yaml" ] || [ -f "$dir/compose.yml" ] || [ -f "$dir/docker-compose.yaml" ] || [ -f "$dir/docker-compose.yml" ] || [ -f "$dir/indirect" ]; then
             if [ -f "$dir/autostart" ]; then
                 autostart=${dir}/autostart
                 if [ 'true' == "$(< "${autostart}" )" ]; then
                     name=${dir}/name
                     name=$(< "${name}")
                     name=$(sanitize ${name})
+                    # Find the compose file
+                    compose_file=""
+                    if [ -f "$dir/compose.yaml" ]; then
+                        compose_file="$dir/compose.yaml"
+                        override_file="$dir/compose.override.yml"
+                    elif [ -f "$dir/compose.yml" ]; then
+                        compose_file="$dir/compose.yml"
+                        override_file="$dir/compose.override.yml"
+                    elif [ -f "$dir/docker-compose.yaml" ]; then
+                        compose_file="$dir/docker-compose.yaml"
+                        override_file="$dir/docker-compose.override.yml"
+                    elif [ -f "$dir/docker-compose.yml" ]; then
+                        compose_file="$dir/docker-compose.yml"
+                        override_file="$dir/docker-compose.override.yml"
+                    fi
+                    
                     override=""
-                    if [ -f "$dir/docker-compose.override.yml" ]; then
-                        override="$dir/docker-compose.override.yml"
+                    if [ -n "$compose_file" ] && [ -f "$override_file" ]; then
+                        override="$override_file"
                         override="-f ${override@Q}"
                     fi
                     envpath=""
@@ -50,8 +67,7 @@ for dir in $COMPOSE_ROOT/*; do
                         indirect=$(< "${indirect}")
                         eval $COMPOSE_WRAPPER -c up -d ${indirect@Q} -p ${name} $recreate $debug $override $envpath > /dev/null &
                     else
-                        dir="$dir/docker-compose.yml"
-                        eval $COMPOSE_WRAPPER -c up -f ${dir@Q} -p ${name} $recreate $debug $override $envpath > /dev/null &
+                        eval $COMPOSE_WRAPPER -c up -f ${compose_file@Q} -p ${name} $recreate $debug $override $envpath > /dev/null &
                     fi
                 fi
             fi

--- a/source/compose.manager/event/stopping_docker
+++ b/source/compose.manager/event/stopping_docker
@@ -8,12 +8,29 @@ COMPOSE_WRAPPER=/usr/local/emhttp/plugins/compose.manager/scripts/compose.sh
 
 for dir in $COMPOSE_ROOT/*; do
     if [ -d "$dir" ]; then
-        if [ -f "$dir/docker-compose.yml" ] || [ -f "$dir/indirect" ]; then
+        # Check if any valid compose file exists
+        if [ -f "$dir/compose.yaml" ] || [ -f "$dir/compose.yml" ] || [ -f "$dir/docker-compose.yaml" ] || [ -f "$dir/docker-compose.yml" ] || [ -f "$dir/indirect" ]; then
             name=${dir}/name
             name=$(< "${name}")
+            # Find the compose file
+            compose_file=""
+            if [ -f "$dir/compose.yaml" ]; then
+                compose_file="$dir/compose.yaml"
+                override_file="$dir/compose.override.yml"
+            elif [ -f "$dir/compose.yml" ]; then
+                compose_file="$dir/compose.yml"
+                override_file="$dir/compose.override.yml"
+            elif [ -f "$dir/docker-compose.yaml" ]; then
+                compose_file="$dir/docker-compose.yaml"
+                override_file="$dir/docker-compose.override.yml"
+            elif [ -f "$dir/docker-compose.yml" ]; then
+                compose_file="$dir/docker-compose.yml"
+                override_file="$dir/docker-compose.override.yml"
+            fi
+            
             override=""
-            if [ -f "$dir/docker-compose.override.yml" ]; then
-                override="$dir/docker-compose.override.yml"
+            if [ -n "$compose_file" ] && [ -f "$override_file" ]; then
+                override="$override_file"
                 override="-f ${override@Q}"
             fi
             envpath=""
@@ -28,8 +45,7 @@ for dir in $COMPOSE_ROOT/*; do
                 indirect=$(< "${indirect}")
                 eval $COMPOSE_WRAPPER -c stop -d ${indirect@Q} -p "${name// /_}" $override $envpath > /dev/null &
             else
-                dir="$dir/docker-compose.yml"
-                eval $COMPOSE_WRAPPER -c stop -f ${dir@Q} -p "${name// /_}" $override $envpath > /dev/null &
+                eval $COMPOSE_WRAPPER -c stop -f ${compose_file@Q} -p "${name// /_}" $override $envpath > /dev/null &
             fi
         fi
     fi

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -637,18 +637,14 @@ function saveEdit() {
   var scriptContents = editor.getValue();
   var actionStr = null
 
-  switch(fileName) {
-    case 'docker-compose.yml':
-      actionStr = 'saveYml'
-      break;
-
-    case '.env':
-      actionStr = 'saveEnv'
-      break;
-
-    default:
-      $(".editing").hide();
-      return;
+  // Check if this is a compose file (any valid extension)
+  if (fileName.match(/^(docker-)?compose\.(yml|yaml)$/)) {
+    actionStr = 'saveYml'
+  } else if (fileName === '.env') {
+    actionStr = 'saveEnv'
+  } else {
+    $(".editing").hide();
+    return;
   }
 
   $.post(caURL,{action:actionStr,script:project,scriptContents:scriptContents},function(data) {

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -33,7 +33,7 @@ if ( ! is_array($composeProjects) ) {
 }
 $o = "";
 foreach ($composeProjects as $project) {
-  if ( ( ! is_file("$compose_root/$project/docker-compose.yml") ) &&
+  if ( ( findComposeFile("$compose_root/$project") === null ) &&
        ( ! is_file("$compose_root/$project/indirect") ) ) {
     continue;
   }
@@ -596,7 +596,9 @@ function editComposeFile(myID) {
       editor.getSession().setOptions({ tabSize: 2, useSoftTabs: true });
 
       $('#editorFileName').data("stackname", project);
-      $('#editorFileName').data("stackfilename", "docker-compose.yml")
+      // Extract the actual filename from the response
+      var filename = response.fileName.split('/').pop();
+      $('#editorFileName').data("stackfilename", filename)
       $('#editorFileName').html(response.fileName)
       $(".editing").show();
 			window.scrollTo(0, 0);

--- a/source/compose.manager/php/compose_util.php
+++ b/source/compose.manager/php/compose_util.php
@@ -71,7 +71,27 @@ function echoComposeCommand($action)
 		}
 		$composeCommand[] = $composeFile;
 
-		// Handle override file based on the base compose file name
+		// First, always include the plugin's override file if it exists
+		global $compose_root;
+		$projectName = basename($path);
+		$pluginOverrideYml = "$compose_root/$projectName/docker-compose.override.yml";
+		$pluginOverrideYaml = "$compose_root/$projectName/docker-compose.override.yaml";
+		
+		if (is_file($pluginOverrideYml)) {
+			$composeOverride = "-f$pluginOverrideYml";
+			$composeCommand[] = $composeOverride;
+			if ( $debug ) {
+				logger("Using plugin override file: $pluginOverrideYml");
+			}
+		} else if (is_file($pluginOverrideYaml)) {
+			$composeOverride = "-f$pluginOverrideYaml";
+			$composeCommand[] = $composeOverride;
+			if ( $debug ) {
+				logger("Using plugin override file: $pluginOverrideYaml");
+			}
+		}
+
+		// Then, also include any project-specific override files
 		if (isIndirect($path)) {
 			$basePath = getPath($path);
 		} else {
@@ -87,15 +107,24 @@ function echoComposeCommand($action)
 			if (is_file($overrideFile)) {
 				$composeOverride = "-f$overrideFile";
 				$composeCommand[] = $composeOverride;
+				if ( $debug ) {
+					logger("Using project override file: $overrideFile");
+				}
 			}
 		} else {
 			// Check for both yml and yaml override files
-			if (is_file("$path/docker-compose.override.yml")) {
-				$composeOverride = "-f$path/docker-compose.override.yml";
+			if (is_file("$basePath/docker-compose.override.yml")) {
+				$composeOverride = "-f$basePath/docker-compose.override.yml";
 				$composeCommand[] = $composeOverride;
-			} else if (is_file("$path/docker-compose.override.yaml")) {
-				$composeOverride = "-f$path/docker-compose.override.yaml";
+				if ( $debug ) {
+					logger("Using project override file: $basePath/docker-compose.override.yml");
+				}
+			} else if (is_file("$basePath/docker-compose.override.yaml")) {
+				$composeOverride = "-f$basePath/docker-compose.override.yaml";
 				$composeCommand[] = $composeOverride;
+				if ( $debug ) {
+					logger("Using project override file: $basePath/docker-compose.override.yaml");
+				}
 			}
 		}
 

--- a/source/compose.manager/php/util.php
+++ b/source/compose.manager/php/util.php
@@ -1,5 +1,40 @@
 <?php
 
+/**
+ * Find the first valid compose file in a directory following Docker Compose priority order
+ *
+ * @param string $dir Directory to search in
+ * @return string|null Path to the first valid compose file found, or null if none found
+ */
+function findComposeFile($dir) {
+    // Docker Compose priority order: compose.yaml, compose.yml, docker-compose.yaml, docker-compose.yml
+    $possibleFiles = [
+        "$dir/compose.yaml",
+        "$dir/compose.yml",
+        "$dir/docker-compose.yaml",
+        "$dir/docker-compose.yml"
+    ];
+    
+    foreach ($possibleFiles as $file) {
+        if (file_exists($file)) {
+            return $file;
+        }
+    }
+    
+    return null;
+}
+
+/**
+ * Get the base name of a compose file without extension
+ *
+ * @param string $composeFilePath Full path to compose file
+ * @return string Base name (e.g., "compose" or "docker-compose")
+ */
+function getComposeFileBaseName($composeFilePath) {
+    $filename = basename($composeFilePath);
+    return pathinfo($filename, PATHINFO_FILENAME);
+}
+
 function sanitizeStr($a) {
 	$a = str_replace(".","_",$a);
 	$a = str_replace(" ","_",$a);


### PR DESCRIPTION
Hey, i have been using your compose plugin for quite a while. I noticed, that the file name for the compose file is hardcoded to be "docker-compose.yml".
I tried to add a compose stack for "Perplexica" which uses "docker-compose.yaml", which resulted in the problem, that the stack in the webui kept creating the docker-compose.yml file instead of using docker-compose.yaml
This annoyed me. I also found the comment here https://github.com/dcflachs/compose_plugin/issues/7#issuecomment-1229208998 talking about the namings for the files as per spec.
So i decied to tackle this and implemented code to support the four different file names.

I also created test projects on my unraid server locally and tested if this is working:
![grafik](https://github.com/user-attachments/assets/55708874-70ce-43de-890c-0413a12dbcca)
This shows the five test projects i created. The first four are the different compose file namings as per spec created manually, the fifth is when creating a stack through the gui instead of using an on-disk stack
![grafik](https://github.com/user-attachments/assets/9050fb1b-7691-4c9f-a5ec-dc7d045c6c17)
![grafik](https://github.com/user-attachments/assets/f24be15a-27b8-47c2-90df-08ee98316c9c)
![grafik](https://github.com/user-attachments/assets/41c116b7-b3ef-48d5-a0c9-a51349a57cbd)
![grafik](https://github.com/user-attachments/assets/6211a971-ea5d-4365-86bc-dfbd2d0b77e5)
This is the perplexica stack. Previously this was empty as the compose plugin always created an empty file "docker-compose.yml" and didnt use the "docker-compose.yaml" file.
![grafik](https://github.com/user-attachments/assets/cb7d638b-b2f9-4bff-9040-7265aae9951c)
Perplexica runs now without problems