### PR TITLE
Add tabbed editor modal for compose files

### DIFF
--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -634,7 +634,10 @@ function updateValidation(type, content, isValid, errorMsg) {
     // Truncate error message to first line for cleaner display
     var shortError = errorMsg.split('\n')[0].substring(0, 100);
     if (errorMsg.length > 100) shortError += '...';
-    validationEl.html('<i class="fa fa-times editor-validation-icon"></i> YAML Error: ' + shortError);
+    // Use text node to prevent XSS from malicious YAML content
+    validationEl.empty()
+      .append('<i class="fa fa-times editor-validation-icon"></i> YAML Error: ')
+      .append(document.createTextNode(shortError));
     validationEl.removeClass('valid warning').addClass('error');
   }
 }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -631,7 +631,10 @@ function updateValidation(type, content, isValid, errorMsg) {
     validationEl.html('<i class="fa fa-check editor-validation-icon"></i> YAML syntax is valid');
     validationEl.removeClass('error warning').addClass('valid');
   } else {
-    validationEl.html('<i class="fa fa-times editor-validation-icon"></i> YAML Error: ' + errorMsg);
+    // Truncate error message to first line for cleaner display
+    var shortError = errorMsg.split('\n')[0].substring(0, 100);
+    if (errorMsg.length > 100) shortError += '...';
+    validationEl.html('<i class="fa fa-times editor-validation-icon"></i> YAML Error: ' + shortError);
     validationEl.removeClass('valid warning').addClass('error');
   }
 }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -584,9 +584,9 @@ function loadEditorFiles(project) {
 }
 
 function switchEditorTab(tabName) {
-  // Update tab buttons
-  $('.editor-tab').removeClass('active');
-  $('#editor-tab-' + tabName).addClass('active');
+  // Update tab buttons and ARIA states
+  $('.editor-tab').removeClass('active').attr('aria-selected', 'false');
+  $('#editor-tab-' + tabName).addClass('active').attr('aria-selected', 'true');
   
   // Update editor containers
   $('.editor-container').removeClass('active');
@@ -1060,29 +1060,29 @@ function ComposeLogs(myID) {
 <BODY>
 
 <!-- Editor Modal -->
-<div id="editor-modal-overlay" class="editor-modal-overlay">
+<div id="editor-modal-overlay" class="editor-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="editor-modal-title">
   <div class="editor-modal">
     <!-- Modal Header -->
     <div class="editor-modal-header">
       <h2 class="editor-modal-title" id="editor-modal-title">Edit Stack</h2>
-      <button class="editor-modal-close" onclick="closeEditorModal()">
+      <button class="editor-modal-close" onclick="closeEditorModal()" aria-label="Close editor modal">
         <i class="fa fa-times"></i>
       </button>
     </div>
     
     <!-- Tab Bar -->
-    <div class="editor-tabs">
-      <button class="editor-tab active" id="editor-tab-compose" onclick="switchEditorTab('compose')">
+    <div class="editor-tabs" role="tablist">
+      <button class="editor-tab active" id="editor-tab-compose" onclick="switchEditorTab('compose')" role="tab" aria-selected="true" aria-controls="editor-container-compose">
         <i class="fa fa-file-code-o"></i>
         docker-compose.yml
         <span class="editor-tab-modified"></span>
       </button>
-      <button class="editor-tab" id="editor-tab-env" onclick="switchEditorTab('env')">
+      <button class="editor-tab" id="editor-tab-env" onclick="switchEditorTab('env')" role="tab" aria-selected="false" aria-controls="editor-container-env">
         <i class="fa fa-cog"></i>
         .env
         <span class="editor-tab-modified"></span>
       </button>
-      <button class="editor-tab" id="editor-tab-override" onclick="switchEditorTab('override')">
+      <button class="editor-tab" id="editor-tab-override" onclick="switchEditorTab('override')" role="tab" aria-selected="false" aria-controls="editor-container-override">
         <i class="fa fa-files-o"></i>
         docker-compose.override.yml
         <span class="editor-tab-modified"></span>
@@ -1092,17 +1092,17 @@ function ComposeLogs(myID) {
     <!-- Editor Body -->
     <div class="editor-modal-body">
       <!-- Compose Editor -->
-      <div class="editor-container active" id="editor-container-compose">
+      <div class="editor-container active" id="editor-container-compose" role="tabpanel" aria-labelledby="editor-tab-compose">
         <div id="editor-compose" style="width: 100%; height: 100%;"></div>
       </div>
       
       <!-- ENV Editor -->
-      <div class="editor-container" id="editor-container-env">
+      <div class="editor-container" id="editor-container-env" role="tabpanel" aria-labelledby="editor-tab-env">
         <div id="editor-env" style="width: 100%; height: 100%;"></div>
       </div>
       
       <!-- Override Editor -->
-      <div class="editor-container" id="editor-container-override">
+      <div class="editor-container" id="editor-container-override" role="tabpanel" aria-labelledby="editor-tab-override">
         <div id="editor-override" style="width: 100%; height: 100%;"></div>
       </div>
     </div>

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -666,7 +666,13 @@ function saveCurrentTab() {
   var currentTab = editorModal.currentTab;
   if (!currentTab || !editorModal.modifiedTabs.has(currentTab)) return;
   
-  saveTab(currentTab);
+  saveTab(currentTab).then(function() {
+    // Brief feedback in validation panel
+    $('#editor-validation').html('<i class="fa fa-check editor-validation-icon"></i> Saved!').removeClass('error warning').addClass('valid');
+    setTimeout(function() {
+      validateYaml(currentTab, editorModal.editors[currentTab].getValue());
+    }, 1500);
+  });
 }
 
 function saveTab(tabName) {
@@ -703,6 +709,13 @@ function saveTab(tabName) {
       
       return true;
     }
+    return false;
+  }).fail(function() {
+    swal2({
+      title: "Save Failed",
+      text: "Failed to save " + tabName + " file. Please try again.",
+      icon: "error"
+    });
     return false;
   });
 }

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -267,8 +267,8 @@ function initEditorModal() {
     editorModal.editors[type] = editor;
   });
   
-  // Keyboard shortcuts
-  $(document).on('keydown', function(e) {
+  // Keyboard shortcuts - use namespaced event to avoid duplicates
+  $(document).off('keydown.editorModal').on('keydown.editorModal', function(e) {
     if ($('#editor-modal-overlay').hasClass('active')) {
       // Ctrl+S or Cmd+S to save current
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -760,6 +760,13 @@ function doCloseEditorModal() {
   $('#editor-modal-overlay').removeClass('active');
   editorModal.currentProject = null;
   editorModal.modifiedTabs = new Set();
+  editorModal.originalContent = {};
+  // Clear editor content to avoid showing stale content on next open
+  ['compose', 'env', 'override'].forEach(function(type) {
+    if (editorModal.editors[type]) {
+      editorModal.editors[type].setValue('', -1);
+    }
+  });
 }
 
 function build_override_input_table( id, value, label, placeholder, disable=false) {

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -181,8 +181,19 @@ var editorModal = {
   currentTab: null,
   originalContent: {},
   modifiedTabs: new Set(),
-  currentProject: null
+  currentProject: null,
+  validationTimeout: null
 };
+
+// Debounce helper for validation
+function debounceValidation(type, content) {
+  if (editorModal.validationTimeout) {
+    clearTimeout(editorModal.validationTimeout);
+  }
+  editorModal.validationTimeout = setTimeout(function() {
+    validateYaml(type, content);
+  }, 300);
+}
 
 // Calculate unRAID header offset dynamically
 function updateModalOffset() {
@@ -250,7 +261,7 @@ function initEditorModal() {
       }
       
       updateSaveButtonState();
-      validateYaml(type, currentContent);
+      debounceValidation(type, currentContent);
     });
     
     editorModal.editors[type] = editor;

--- a/source/compose.manager/php/compose_manager_main.php
+++ b/source/compose.manager/php/compose_manager_main.php
@@ -576,10 +576,8 @@ function loadEditorFiles(project) {
   
   // When all files are loaded
   $.when.apply($, loadPromises).then(function() {
-    // Activate the compose tab by default
+    // Activate the compose tab by default (also runs validation)
     switchEditorTab('compose');
-    // Run validation on the initial content
-    validateYaml('compose', editorModal.editors['compose'].getValue());
   }).fail(function() {
     $('#editor-validation').html('<i class="fa fa-exclamation-triangle editor-validation-icon"></i> Error loading some files').removeClass('valid').addClass('error');
   });

--- a/source/compose.manager/styles/editorModal.css
+++ b/source/compose.manager/styles/editorModal.css
@@ -1,0 +1,76 @@
+/* Editor Modal - Uses unRAID CSS variables where possible */
+.editor-modal-overlay {
+  --unraid-header-offset: 140px;
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 9999;
+  overflow: auto;
+  padding: 20px;
+  padding-top: calc(var(--unraid-header-offset) + 10px);
+  box-sizing: border-box;
+}
+.editor-modal-overlay.active { display: flex; justify-content: center; align-items: flex-start; }
+
+.editor-modal {
+  width: 95%;
+  height: calc(100vh - var(--unraid-header-offset) - 40px);
+  max-width: 1400px;
+  background-color: var(--background-color, #1c1c1c);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border-color, #3a3a3a);
+}
+
+.editor-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 20px;
+  background-color: var(--alt-background-color, #252525);
+  border-bottom: 1px solid var(--border-color, #3a3a3a);
+  border-radius: 8px 8px 0 0;
+}
+.editor-modal-title { font-size: 1.4rem; color: var(--brand-orange, #ff8c2f); font-weight: bold; margin: 0; }
+.editor-modal-close { background: none; border: none; color: var(--alt-text-color, #888); font-size: 1.5rem; cursor: pointer; padding: 5px 10px; }
+.editor-modal-close:hover { color: var(--brand-red, #ff4444); }
+
+.editor-tabs { display: flex; background-color: var(--background-color, #1e1e1e); border-bottom: 1px solid var(--border-color, #3a3a3a); padding: 0 10px; }
+.editor-tab { padding: 12px 20px; background: transparent; border: none; color: var(--alt-text-color, #888); cursor: pointer; font-size: 0.95rem; border-bottom: 2px solid transparent; display: flex; align-items: center; gap: 8px; }
+.editor-tab:hover { color: var(--text-color, #ccc); background-color: var(--alt-background-color, #2a2a2a); }
+.editor-tab.active { color: var(--brand-orange, #ff8c2f); border-bottom-color: var(--brand-orange, #ff8c2f); background-color: var(--alt-background-color, #2a2a2a); }
+.editor-tab i { font-size: 0.85rem; }
+.editor-tab-modified { width: 8px; height: 8px; background-color: var(--brand-orange, #ff8c2f); border-radius: 50%; display: none; }
+.editor-tab.modified .editor-tab-modified { display: inline-block; }
+
+.editor-modal-body { flex: 1; display: flex; flex-direction: column; overflow: hidden; position: relative; }
+.editor-container { flex: 1; position: relative; display: none; }
+.editor-container.active { display: block; }
+.editor-container .ace_editor { position: absolute; top: 0; left: 0; right: 0; bottom: 0; }
+
+.editor-validation { padding: 10px 20px; background-color: var(--background-color, #1a1a1a); border-top: 1px solid var(--border-color, #3a3a3a); font-family: monospace; font-size: 1.1rem; }
+.editor-validation.valid { color: #4caf50; }
+.editor-validation.error { color: #f44336; }
+.editor-validation-icon { margin-right: 8px; }
+
+.editor-modal-footer { display: flex; justify-content: space-between; align-items: center; padding: 12px 20px; background-color: var(--alt-background-color, #252525); border-top: 1px solid var(--border-color, #3a3a3a); border-radius: 0 0 8px 8px; }
+.editor-footer-left { display: flex; align-items: center; gap: 15px; }
+.editor-footer-right { display: flex; gap: 10px; }
+.editor-file-info { color: var(--alt-text-color, #888); font-size: 1.1rem; }
+
+.editor-btn { padding: 10px 25px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.95rem; }
+.editor-btn-cancel { background-color: var(--alt-background-color, #3a3a3a); color: var(--text-color, #ccc); }
+.editor-btn-cancel:hover { background-color: var(--border-color, #4a4a4a); }
+.editor-btn-save { background: var(--button-background, linear-gradient(90deg,#e22828,#ff8c2f)); color: #fff; }
+.editor-btn-save:disabled { background: var(--disabled-input-background-color, #5a5a5a); color: var(--disabled-text-color, #888); cursor: not-allowed; }
+.editor-btn-save-all { background-color: #4caf50; color: #fff; }
+.editor-btn-save-all:hover { background-color: #5cbf60; }
+
+.editor-shortcuts { color: var(--alt-text-color, #666); font-size: 0.8rem; }
+.editor-shortcuts kbd { background-color: var(--alt-background-color, #3a3a3a); padding: 2px 6px; border-radius: 3px; font-family: monospace; }

--- a/source/compose.manager/styles/editorModal.css
+++ b/source/compose.manager/styles/editorModal.css
@@ -67,10 +67,10 @@
 .editor-btn { padding: 10px 25px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.95rem; }
 .editor-btn-cancel { background-color: var(--alt-background-color, #3a3a3a); color: var(--text-color, #ccc); }
 .editor-btn-cancel:hover { background-color: var(--border-color, #4a4a4a); }
-.editor-btn-save { background: var(--button-background, linear-gradient(90deg,#e22828,#ff8c2f)); color: #fff; }
-.editor-btn-save:disabled { background: var(--disabled-input-background-color, #5a5a5a); color: var(--disabled-text-color, #888); cursor: not-allowed; }
 .editor-btn-save-all { background-color: #4caf50; color: #fff; }
 .editor-btn-save-all:hover { background-color: #5cbf60; }
+.editor-btn-save-all:disabled { background: var(--disabled-input-background-color, #5a5a5a); color: var(--disabled-text-color, #888); cursor: not-allowed; }
+.editor-btn-save-all:disabled:hover { background-color: var(--disabled-input-background-color, #5a5a5a); }
 
 .editor-shortcuts { color: var(--alt-text-color, #666); font-size: 0.8rem; }
 .editor-shortcuts kbd { background-color: var(--alt-background-color, #3a3a3a); padding: 2px 6px; border-radius: 3px; font-family: monospace; }

--- a/source/compose.manager/styles/editorModal.css
+++ b/source/compose.manager/styles/editorModal.css
@@ -40,11 +40,13 @@
 .editor-modal-title { font-size: 1.4rem; color: var(--brand-orange, #ff8c2f); font-weight: bold; margin: 0; }
 .editor-modal-close { background: none; border: none; color: var(--alt-text-color, #888); font-size: 1.5rem; cursor: pointer; padding: 5px 10px; }
 .editor-modal-close:hover { color: var(--brand-red, #ff4444); }
+.editor-modal-close:focus-visible { outline: 2px solid var(--brand-orange, #ff8c2f); outline-offset: 2px; }
 
 .editor-tabs { display: flex; background-color: var(--background-color, #1e1e1e); border-bottom: 1px solid var(--border-color, #3a3a3a); padding: 0 10px; }
 .editor-tab { padding: 12px 20px; background: transparent; border: none; color: var(--alt-text-color, #888); cursor: pointer; font-size: 0.95rem; border-bottom: 2px solid transparent; display: flex; align-items: center; gap: 8px; }
 .editor-tab:hover { color: var(--text-color, #ccc); background-color: var(--alt-background-color, #2a2a2a); }
 .editor-tab.active { color: var(--brand-orange, #ff8c2f); border-bottom-color: var(--brand-orange, #ff8c2f); background-color: var(--alt-background-color, #2a2a2a); }
+.editor-tab:focus-visible { outline: 2px solid var(--brand-orange, #ff8c2f); outline-offset: -2px; }
 .editor-tab i { font-size: 0.85rem; }
 .editor-tab-modified { width: 8px; height: 8px; background-color: var(--brand-orange, #ff8c2f); border-radius: 50%; display: none; }
 .editor-tab.modified .editor-tab-modified { display: inline-block; }


### PR DESCRIPTION
## Summary
Replace separate Compose/ENV file editing dialogs with a unified full-screen editor modal.

## Changes
- **New tabbed editor modal** with tabs for docker-compose.yml, .env, and docker-compose.override.yml files
- **Real-time YAML syntax validation** using js-yaml library
- **Visual change tracking** with indicators on modified tabs
- **Keyboard shortcuts**: Ctrl+S to save current file, Escape to close
- **Unsaved changes warning** when closing with modifications
- **Dynamic positioning** that adapts to unRAID header height
- **Theme support** using unRAID CSS variables for dark/light mode compatibility

## UI Changes
- Consolidates 'Compose File' and 'ENV File' buttons into single 'Edit Files' action
- Full-screen modal provides more editing space than previous inline editor
- Tab interface allows quick switching between related files

## Testing
Tested on unRAID 7.1.4 with both dark (black) and light (azure) themes.